### PR TITLE
feat: Add Jakub Skywalker to Zurich Cloud Summit participants

### DIFF
--- a/workshops/2025-Q3-summits/20250924-Zurich.md
+++ b/workshops/2025-Q3-summits/20250924-Zurich.md
@@ -1,0 +1,5 @@
+# Zurich - Cloud Summit Participants
+
+| Time | GitHub Username | Computer Type | Issue URL |
+|---|---|
+| 20250924 14:59 | jakubpawlowski | Mac | https://github.com/jakubpawlowski/gemini-cli-demos/issues/1 |

--- a/workshops/2025-Q3-summits/workshop-20250924-145728.yaml
+++ b/workshops/2025-Q3-summits/workshop-20250924-145728.yaml
@@ -7,6 +7,7 @@ student:
   user_name_and_surname: "Jakub Skywalker"
   computer_type: "Darwin"
   random_pin: "22801"
+  issue: https://github.com/palladius/gemini-cli-demos/issues/24
 workshop:
   name: "Zurich - Cloud Summit"
   secret_keyword: "Cuechicashli"

--- a/workshops/2025-Q3-summits/workshop-20250924-145728.yaml
+++ b/workshops/2025-Q3-summits/workshop-20250924-145728.yaml
@@ -1,0 +1,13 @@
+student:
+  workshop_command_version: "1.1.0_23sep25"
+  username: "jakub"
+  todays_date: "20250924-145728"
+  teacher_name: "Riccardo"
+  github_username: "jakubpawlowski"
+  user_name_and_surname: "Jakub Skywalker"
+  computer_type: "Darwin"
+  random_pin: "22801"
+workshop:
+  name: "Zurich - Cloud Summit"
+  secret_keyword: "Cuechicashli"
+  zip_code: "41044"


### PR DESCRIPTION
This PR adds Jakub Skywalker to the list of participants for the Zurich Cloud Summit workshop.\n\n- GitHub Username: jakubpawlowski\n- Computer Type: Mac\n- Issue URL: https://github.com/jakubpawlowski/gemini-cli-demos/issues/1\n\nThis change is part of the Gemini CLI Workshop experience.